### PR TITLE
Two of the vnfds that the slm-ia test are using where missing the uui…

### DIFF
--- a/int-slm-infrabstractV2/test-trigger/test_trigger/exampleplugin.py
+++ b/int-slm-infrabstractV2/test-trigger/test_trigger/exampleplugin.py
@@ -78,7 +78,7 @@ class DemoPlugin1(ManoBasePlugin):
         Plugin logic. Does nothing in our example.
         """
         LOG.debug('corr_id:'+self.correlation_id)
-        time.sleep(720)
+        time.sleep(360)
         LOG.debug('Timeout')
         os._exit(1)
 

--- a/int-slm-infrabstractV2/test-trigger/test_trigger/test_descriptors/fw-vnf-vnfd.yml
+++ b/int-slm-infrabstractV2/test-trigger/test_trigger/test_descriptors/fw-vnf-vnfd.yml
@@ -72,3 +72,4 @@ connection_points:
   - id: "vnf:output"
     interface: "ipv4"
     type: "internal"
+uuid: 9df6a98f-9e11-4cb7-b3c0-b1375e7ca1a9

--- a/int-slm-infrabstractV2/test-trigger/test_trigger/test_descriptors/vtc-vnf-vnfd.yml
+++ b/int-slm-infrabstractV2/test-trigger/test_trigger/test_descriptors/vtc-vnf-vnfd.yml
@@ -103,3 +103,4 @@ monitoring_rules:
     notification:
       - name: "notification04"
         type: "rabbitmq_message"
+uuid: 9df6a98f-9e11-4cb7-b3c0-b1375e7ca1aa


### PR DESCRIPTION
…d field. Timeout of test reduced to 6 minutes.